### PR TITLE
Fixes header case change in PHP 7.3+

### DIFF
--- a/util.php
+++ b/util.php
@@ -1,27 +1,26 @@
 <?php
 
-function curl_post($url, array $post = NULL, array $options = array()) 
-{ 
-    $defaults = array( 
-        CURLOPT_POST => 1, 
-        CURLOPT_HEADER => 0, 
-        CURLOPT_URL => $url, 
-        CURLOPT_FRESH_CONNECT => 1, 
-        CURLOPT_RETURNTRANSFER => 1, 
-        CURLOPT_FORBID_REUSE => 1, 
-        CURLOPT_TIMEOUT => 4, 
-        CURLOPT_POSTFIELDS => http_build_query($post) 
-    ); 
+function curl_post($url, array $post = NULL, array $options = array())
+{
+    $defaults = array(
+        CURLOPT_POST => 1,
+        CURLOPT_HEADER => 0,
+        CURLOPT_URL => $url,
+        CURLOPT_FRESH_CONNECT => 1,
+        CURLOPT_RETURNTRANSFER => 1,
+        CURLOPT_FORBID_REUSE => 1,
+        CURLOPT_TIMEOUT => 4,
+        CURLOPT_POSTFIELDS => http_build_query($post)
+    );
 
-    $ch = curl_init(); 
-    curl_setopt_array($ch, ($options + $defaults)); 
-    if( ! $response = curl_exec($ch)) 
-    { 
-        trigger_error(curl_error($ch)); 
-    } 
-    //$request = curl_getinfo($ch);
+    $ch = curl_init();
+    curl_setopt_array($ch, ($options + $defaults));
+    if( ! $response = curl_exec($ch))
+    {
+        trigger_error(curl_error($ch));
+    }
     curl_close($ch);
-    return $response; 
+    return $response;
 }
 
 function http_parse($res){
@@ -34,8 +33,9 @@ function http_parse($res){
     foreach ($headers as $value) {
         $header = preg_split("/: /", $value);
         if(count($header) == 2){
-            switch($header[0]){
-                case "Set-Cookie":
+            $header_key = strtolower($header[0]);
+            switch($header_key){
+                case "set-cookie":
                     if(!array_key_exists("Set-Cookie", $parsed['headers'])){
                         $parsed['headers']['Set-Cookie'] = array();
                     }
@@ -45,11 +45,10 @@ function http_parse($res){
                     $parsed['headers']['Set-Cookie'][$cookie_name] = array_combine($values[1], $values[2]);
                     break;
                 default:
-                    $parsed['headers'][$header[0]] = $header[1];
+                    $parsed['headers'][$header_key] = $header[1];
             }
         }
     }
     $parsed['body'] = $matches[2];
     return $parsed;
 }
-


### PR DESCRIPTION
In PHP 7.3, CURL is sending headers in lowercase. I'm not entirely sure why that happens. This causes the auth token to not be saved when auth is successful. This change makes `http_parse()` understand headers with any casing.

There are also some whitespace changes caused by my editor. I recommend turning off whitespace when reviewing this PR.