### PR TITLE
Add PHP 8 support by fixing constructors

### DIFF
--- a/client.php
+++ b/client.php
@@ -12,11 +12,12 @@ class TritonClient {
     var $password;
     var $url;
 
+    // PHP 4 style constructor for backwards-compatibility.
     function TritonClient($alias, $password, $version = 7){
-        $this::__constructor($alias, $password, $version);
+        $this::__construct($alias, $password, $version);
     }
 
-    function __constructor($alias, $password, $version = 7)
+    function __construct($alias, $password, $version = 7)
     {
         $this->version = $version;
         $this->auth_cookie = "";

--- a/game.php
+++ b/game.php
@@ -4,10 +4,12 @@ Class TritonGame {
     var $client;
     var $id;
 
+    // PHP 4 style constructor for backwards-compatibility.
     function TritonGame($client, $game_id){
         $this::__constructor($client, $game_id);
     }
-    function __constructor($client, $game_id)
+
+    function __construct($client, $game_id)
     {
         $this->client = $client;
         $this->id = $game_id;

--- a/game.php
+++ b/game.php
@@ -6,7 +6,7 @@ Class TritonGame {
 
     // PHP 4 style constructor for backwards-compatibility.
     function TritonGame($client, $game_id){
-        $this::__constructor($client, $game_id);
+        $this::__construct($client, $game_id);
     }
 
     function __construct($client, $game_id)

--- a/server.php
+++ b/server.php
@@ -3,14 +3,16 @@
 Class TritonServer {
     var $client;
 
+    // PHP 4 style constructor for backwards-compatibility.
     function TritonServer($client){
-        $this::__constructor($client);
+        $this::__construct($client);
     }
-    function __constructor($client)
+
+    function __construct($client)
     {
         $this->client = $client;
     }
-    
+
     function GetPlayer(){
         return $this->client->serverRequest("init_player");
     }


### PR DESCRIPTION
In PHP 8, PHP 4-style constructors using the same name as the class no longer work. I've kept those constructors for backwards-compatibility, but I've renamed `__constructor` to `__construct` so that PHP 8 can properly detect them.